### PR TITLE
Album Feature: Create, Add, and Select Albums (Offline Support)

### DIFF
--- a/android/app/src/main/kotlin/com/hartvig/solutions/picsor/picsor/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hartvig/solutions/picsor/picsor/MainActivity.kt
@@ -143,6 +143,26 @@ class MainActivity: FlutterActivity() {
                     android.util.Log.e("PicSor", "getAlbums exception", e)
                     result.success(listOf<String>())
                 }
+            } else if (call.method == "createAlbum") {
+                val args = call.arguments as? Map<*, *>
+                val albumName = args?.get("album") as? String
+                if (albumName == null) {
+                    result.success(false)
+                    return@setMethodCallHandler
+                }
+                try {
+                    val albumRoot = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DCIM).absolutePath + "/PicSor/"
+                    val albumFile = java.io.File(albumRoot, albumName)
+                    if (!albumFile.exists()) {
+                        val created = albumFile.mkdirs()
+                        result.success(created)
+                    } else {
+                        result.success(true) // Already exists
+                    }
+                } catch (e: Exception) {
+                    android.util.Log.e("PicSor", "createAlbum exception", e)
+                    result.success(false)
+                }
             } else {
                 result.notImplemented()
             }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -47,6 +47,70 @@ import Photos
         result(FlutterMethodNotImplemented)
       }
     }
+    // Albums platform channel
+    let albumsChannel = FlutterMethodChannel(name: "picsor.albums", binaryMessenger: controller.binaryMessenger)
+    albumsChannel.setMethodCallHandler { (call, result) in
+      if call.method == "addToAlbum" {
+        guard let args = call.arguments as? [String: Any],
+              let id = args["id"] as? String,
+              let albumName = args["album"] as? String else {
+          result(false)
+          return
+        }
+        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [id], options: nil)
+        guard let asset = assets.firstObject else {
+          result(false)
+          return
+        }
+        // Find or create album
+        var albumPlaceholder: PHObjectPlaceholder?
+        var albumCollection: PHAssetCollection?
+        let fetchOptions = PHFetchOptions()
+        fetchOptions.predicate = NSPredicate(format: "title = %@", albumName)
+        let collections = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: fetchOptions)
+        if let found = collections.firstObject {
+          albumCollection = found
+        }
+        PHPhotoLibrary.shared().performChanges({
+          if albumCollection == nil {
+            let createAlbumRequest = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: albumName)
+            albumPlaceholder = createAlbumRequest.placeholderForCreatedAssetCollection
+          }
+        }, completionHandler: { success, error in
+          if !success {
+            result(false)
+            return
+          }
+          // Fetch (possibly newly created) album
+          let fetchOptions = PHFetchOptions()
+          fetchOptions.predicate = NSPredicate(format: "title = %@", albumName)
+          let collections = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: fetchOptions)
+          guard let album = collections.firstObject else {
+            result(false)
+            return
+          }
+          // Add asset to album
+          PHPhotoLibrary.shared().performChanges({
+            if let changeRequest = PHAssetCollectionChangeRequest(for: album) {
+              let assetsArray = NSArray(object: asset)
+              changeRequest.addAssets(assetsArray)
+            }
+          }, completionHandler: { addSuccess, addError in
+            result(addSuccess)
+          })
+        })
+      } else if call.method == "getAlbums" {
+        let fetchOptions = PHFetchOptions()
+        let collections = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: fetchOptions)
+        var albumNames: [String] = []
+        collections.enumerateObjects { (collection, _, _) in
+          albumNames.append(collection.localizedTitle ?? "")
+        }
+        result(albumNames)
+      } else {
+        result(FlutterMethodNotImplemented)
+      }
+    }
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -107,6 +107,25 @@ import Photos
           albumNames.append(collection.localizedTitle ?? "")
         }
         result(albumNames)
+      } else if call.method == "createAlbum" {
+        guard let args = call.arguments as? [String: Any],
+              let albumName = args["album"] as? String else {
+          result(false)
+          return
+        }
+        // Check if album already exists
+        let fetchOptions = PHFetchOptions()
+        fetchOptions.predicate = NSPredicate(format: "title = %@", albumName)
+        let collections = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .any, options: fetchOptions)
+        if collections.firstObject != nil {
+          result(true) // Already exists
+          return
+        }
+        PHPhotoLibrary.shared().performChanges({
+          _ = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: albumName)
+        }, completionHandler: { success, error in
+          result(success)
+        })
       } else {
         result(FlutterMethodNotImplemented)
       }

--- a/lib/screens/swipe_screen.dart
+++ b/lib/screens/swipe_screen.dart
@@ -705,8 +705,85 @@ class _SwipeScreenState extends State<SwipeScreen>
                                 borderRadius: BorderRadius.circular(16),
                                 child: InkWell(
                                   borderRadius: BorderRadius.circular(16),
-                                  onTap: () {
-                                    /* TODO: Add album */
+                                  onTap: () async {
+                                    final controller = TextEditingController();
+                                    final albumName = await showDialog<String>(
+                                      context: context,
+                                      builder: (context) {
+                                        return AlertDialog(
+                                          title: const Text('New Album'),
+                                          content: TextField(
+                                            controller: controller,
+                                            autofocus: true,
+                                            decoration: const InputDecoration(
+                                              hintText: 'Album name',
+                                            ),
+                                          ),
+                                          actions: [
+                                            TextButton(
+                                              onPressed:
+                                                  () =>
+                                                      Navigator.of(
+                                                        context,
+                                                      ).pop(),
+                                              child: const Text('Cancel'),
+                                            ),
+                                            ElevatedButton(
+                                              onPressed: () {
+                                                final name =
+                                                    controller.text.trim();
+                                                if (name.isNotEmpty) {
+                                                  Navigator.of(
+                                                    context,
+                                                  ).pop(name);
+                                                }
+                                              },
+                                              child: const Text('Create'),
+                                            ),
+                                          ],
+                                        );
+                                      },
+                                    );
+                                    if (albumName != null &&
+                                        albumName.isNotEmpty) {
+                                      final created =
+                                          await PhotoActionService.createAlbum(
+                                            albumName,
+                                          );
+                                      if (created) {
+                                        // Opdater listen og tilføj billedet til det nye album
+                                        final ok =
+                                            await PhotoActionService.addToAlbum(
+                                              photo,
+                                              albumName,
+                                            );
+                                        if (!ok) {
+                                          ScaffoldMessenger.of(
+                                            context,
+                                          ).showSnackBar(
+                                            const SnackBar(
+                                              content: Text(
+                                                'Failed to add to new album.',
+                                              ),
+                                            ),
+                                          );
+                                        } else {
+                                          Navigator.of(context).pop(
+                                            albumName,
+                                          ); // luk popup og vælg albummet
+                                        }
+                                      } else {
+                                        ScaffoldMessenger.of(
+                                          context,
+                                        ).showSnackBar(
+                                          const SnackBar(
+                                            content: Text(
+                                              'Could not create album.',
+                                            ),
+                                          ),
+                                        );
+                                      }
+                                    }
                                   },
                                   child: SizedBox(
                                     height: 48,

--- a/lib/screens/swipe_screen.dart
+++ b/lib/screens/swipe_screen.dart
@@ -17,6 +17,14 @@ import '../widgets/swipe_card.dart';
 import '../widgets/swipe_action_button_group.dart';
 import '../widgets/floating_live_label.dart';
 import 'dart:io';
+import 'dart:ui';
+
+class _AlbumInfo {
+  final String name;
+  final int count;
+  final Uint8List? thumb;
+  _AlbumInfo({required this.name, required this.count, this.thumb});
+}
 
 class SwipeScreen extends StatefulWidget {
   final SwipeLogicService swipeLogicService;
@@ -484,11 +492,243 @@ class _SwipeScreenState extends State<SwipeScreen>
     }
   }
 
+  Future<void> _showAlbumPicker(PhotoModel photo) async {
+    final albums = await PhotoActionService.getAlbums();
+    if (albums.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('No albums found.')));
+      return;
+    }
+    final selected = await showDialog<String>(
+      context: context,
+      barrierColor: Colors.transparent,
+      barrierDismissible: true,
+      builder: (context) {
+        return Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => Navigator.of(context).pop(),
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+                  child: Container(color: Colors.black.withOpacity(0.25)),
+                ),
+              ),
+            ),
+            Center(
+              child: Dialog(
+                insetPadding: const EdgeInsets.all(24),
+                child: SizedBox(
+                  width: 350,
+                  height: 420,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Padding(
+                        padding: EdgeInsets.all(16),
+                        child: Text(
+                          'Add to Album',
+                          style: TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                      const Divider(),
+                      Expanded(
+                        child: FutureBuilder<List<_AlbumInfo>>(
+                          future: _fetchAlbumInfos(albums),
+                          builder: (context, snap) {
+                            if (!snap.hasData) {
+                              return const Center(
+                                child: CircularProgressIndicator(),
+                              );
+                            }
+                            final albumInfos = snap.data!;
+                            return ListView.separated(
+                              itemCount: albumInfos.length,
+                              separatorBuilder:
+                                  (_, __) => const SizedBox(height: 8),
+                              itemBuilder: (context, i) {
+                                final info = albumInfos[i];
+                                return Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 12,
+                                  ),
+                                  child: Material(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .surfaceVariant
+                                        .withOpacity(0.8),
+                                    borderRadius: BorderRadius.circular(16),
+                                    child: InkWell(
+                                      borderRadius: BorderRadius.circular(16),
+                                      onTap:
+                                          () => Navigator.of(
+                                            context,
+                                          ).pop(info.name),
+                                      child: SizedBox(
+                                        height: 56,
+                                        child: Row(
+                                          children: [
+                                            if (info.thumb != null)
+                                              ClipRRect(
+                                                borderRadius:
+                                                    const BorderRadius.only(
+                                                      topLeft: Radius.circular(
+                                                        16,
+                                                      ),
+                                                      bottomLeft:
+                                                          Radius.circular(16),
+                                                      topRight: Radius.circular(
+                                                        0,
+                                                      ),
+                                                      bottomRight:
+                                                          Radius.circular(0),
+                                                    ),
+                                                child: Image.memory(
+                                                  info.thumb!,
+                                                  width: 56,
+                                                  height: 56,
+                                                  fit: BoxFit.cover,
+                                                ),
+                                              )
+                                            else
+                                              Container(
+                                                width: 56,
+                                                height: 56,
+                                                decoration: const BoxDecoration(
+                                                  color: Color(0xFFE0E0E0),
+                                                  borderRadius:
+                                                      BorderRadius.only(
+                                                        topLeft:
+                                                            Radius.circular(16),
+                                                        bottomLeft:
+                                                            Radius.circular(16),
+                                                        topRight:
+                                                            Radius.circular(0),
+                                                        bottomRight:
+                                                            Radius.circular(0),
+                                                      ),
+                                                ),
+                                                child: const Icon(
+                                                  Icons.photo,
+                                                  size: 28,
+                                                  color: Colors.grey,
+                                                ),
+                                              ),
+                                            const SizedBox(width: 16),
+                                            Expanded(
+                                              child: Padding(
+                                                padding:
+                                                    const EdgeInsets.symmetric(
+                                                      vertical: 8,
+                                                    ),
+                                                child: Text(
+                                                  info.name,
+                                                  style: const TextStyle(
+                                                    fontSize: 16,
+                                                    fontWeight: FontWeight.w500,
+                                                  ),
+                                                  overflow:
+                                                      TextOverflow.ellipsis,
+                                                ),
+                                              ),
+                                            ),
+                                            const SizedBox(width: 12),
+                                            Row(
+                                              mainAxisSize: MainAxisSize.min,
+                                              children: [
+                                                Text(
+                                                  '${info.count}',
+                                                  style: const TextStyle(
+                                                    fontSize: 14,
+                                                  ),
+                                                ),
+                                                const SizedBox(width: 4),
+                                                const Icon(
+                                                  Icons.photo_library_outlined,
+                                                  size: 18,
+                                                ),
+                                              ],
+                                            ),
+                                            const SizedBox(width: 12),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                );
+                              },
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+    if (selected != null) {
+      final ok = await PhotoActionService.addToAlbum(photo, selected);
+      if (!ok) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to add to album.')));
+      }
+    }
+  }
+
+  // Helper: fetch album info (name, count, thumb)
+  Future<List<_AlbumInfo>> _fetchAlbumInfos(List<String> albums) async {
+    final List<_AlbumInfo> infos = [];
+    for (final name in albums) {
+      try {
+        final paths = await PhotoManager.getAssetPathList(
+          hasAll: false,
+          filterOption: FilterOptionGroup(
+            containsPathModified: false,
+            orders: [
+              const OrderOption(type: OrderOptionType.createDate, asc: false),
+            ],
+          ),
+        );
+        AssetPathEntity? match;
+        try {
+          match = paths.firstWhere((p) => p.name == name);
+        } catch (_) {
+          match = null;
+        }
+        if (match != null) {
+          final count = match.assetCountAsync;
+          final assets = await match.getAssetListRange(start: 0, end: 1);
+          final thumb =
+              assets.isNotEmpty
+                  ? await assets.first.thumbnailDataWithSize(
+                    const ThumbnailSize(80, 80),
+                  )
+                  : null;
+          infos.add(_AlbumInfo(name: name, count: await count, thumb: thumb));
+        } else {
+          infos.add(_AlbumInfo(name: name, count: 0, thumb: null));
+        }
+      } catch (_) {
+        infos.add(_AlbumInfo(name: name, count: 0, thumb: null));
+      }
+    }
+    return infos;
+  }
+
   // Placeholder for add to album
   bool _isInAlbum(PhotoModel photo) => false; // TODO: implement real check
   Future<void> _addToAlbum(PhotoModel photo) async {
-    // TODO: implement add to album logic
-    setState(() {});
+    await _showAlbumPicker(photo);
   }
 
   Future<void> _sharePhoto(PhotoModel photo) async {

--- a/lib/screens/swipe_screen.dart
+++ b/lib/screens/swipe_screen.dart
@@ -531,7 +531,7 @@ class _SwipeScreenState extends State<SwipeScreen>
                         child: Text(
                           'Add to Album',
                           style: TextStyle(
-                            fontSize: 20,
+                            fontSize: 24,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
@@ -548,6 +548,7 @@ class _SwipeScreenState extends State<SwipeScreen>
                             }
                             final albumInfos = snap.data!;
                             return ListView.separated(
+                              padding: const EdgeInsets.only(bottom: 24),
                               itemCount: albumInfos.length,
                               separatorBuilder:
                                   (_, __) => const SizedBox(height: 8),

--- a/lib/screens/swipe_screen.dart
+++ b/lib/screens/swipe_screen.dart
@@ -521,8 +521,8 @@ class _SwipeScreenState extends State<SwipeScreen>
               child: Dialog(
                 insetPadding: const EdgeInsets.all(24),
                 child: SizedBox(
-                  width: 350,
-                  height: 420,
+                  width: 400,
+                  height: 500,
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
@@ -551,122 +551,219 @@ class _SwipeScreenState extends State<SwipeScreen>
                               padding: const EdgeInsets.only(bottom: 24),
                               itemCount: albumInfos.length,
                               separatorBuilder:
-                                  (_, __) => const SizedBox(height: 8),
+                                  (_, __) => const SizedBox(height: 16),
                               itemBuilder: (context, i) {
                                 final info = albumInfos[i];
-                                return Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 12,
-                                  ),
-                                  child: Material(
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .surfaceVariant
-                                        .withOpacity(0.8),
-                                    borderRadius: BorderRadius.circular(16),
-                                    child: InkWell(
-                                      borderRadius: BorderRadius.circular(16),
-                                      onTap:
-                                          () => Navigator.of(
-                                            context,
-                                          ).pop(info.name),
-                                      child: SizedBox(
-                                        height: 56,
-                                        child: Row(
-                                          children: [
-                                            if (info.thumb != null)
-                                              ClipRRect(
-                                                borderRadius:
-                                                    const BorderRadius.only(
-                                                      topLeft: Radius.circular(
-                                                        16,
-                                                      ),
-                                                      bottomLeft:
-                                                          Radius.circular(16),
-                                                      topRight: Radius.circular(
-                                                        0,
-                                                      ),
-                                                      bottomRight:
-                                                          Radius.circular(0),
-                                                    ),
-                                                child: Image.memory(
-                                                  info.thumb!,
-                                                  width: 56,
-                                                  height: 56,
-                                                  fit: BoxFit.cover,
-                                                ),
-                                              )
-                                            else
-                                              Container(
-                                                width: 56,
-                                                height: 56,
-                                                decoration: const BoxDecoration(
-                                                  color: Color(0xFFE0E0E0),
-                                                  borderRadius:
-                                                      BorderRadius.only(
-                                                        topLeft:
-                                                            Radius.circular(16),
-                                                        bottomLeft:
-                                                            Radius.circular(16),
-                                                        topRight:
-                                                            Radius.circular(0),
-                                                        bottomRight:
-                                                            Radius.circular(0),
-                                                      ),
-                                                ),
-                                                child: const Icon(
-                                                  Icons.photo,
-                                                  size: 28,
-                                                  color: Colors.grey,
-                                                ),
-                                              ),
-                                            const SizedBox(width: 16),
-                                            Expanded(
-                                              child: Padding(
-                                                padding:
-                                                    const EdgeInsets.symmetric(
-                                                      vertical: 8,
-                                                    ),
-                                                child: Text(
-                                                  info.name,
-                                                  style: const TextStyle(
-                                                    fontSize: 16,
-                                                    fontWeight: FontWeight.w500,
-                                                  ),
-                                                  overflow:
-                                                      TextOverflow.ellipsis,
-                                                ),
-                                              ),
-                                            ),
-                                            const SizedBox(width: 12),
-                                            Row(
-                                              mainAxisSize: MainAxisSize.min,
+                                return Row(
+                                  children: [
+                                    const SizedBox(width: 24),
+                                    Expanded(
+                                      child: Material(
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .surfaceVariant
+                                            .withOpacity(0.8),
+                                        borderRadius: BorderRadius.circular(16),
+                                        child: InkWell(
+                                          borderRadius: BorderRadius.circular(
+                                            16,
+                                          ),
+                                          onTap:
+                                              () => Navigator.of(
+                                                context,
+                                              ).pop(info.name),
+                                          child: SizedBox(
+                                            height: 56,
+                                            child: Row(
                                               children: [
-                                                Text(
-                                                  '${info.count}',
-                                                  style: const TextStyle(
-                                                    fontSize: 14,
+                                                if (info.thumb != null)
+                                                  ClipRRect(
+                                                    borderRadius:
+                                                        const BorderRadius.only(
+                                                          topLeft:
+                                                              Radius.circular(
+                                                                16,
+                                                              ),
+                                                          bottomLeft:
+                                                              Radius.circular(
+                                                                16,
+                                                              ),
+                                                          topRight:
+                                                              Radius.circular(
+                                                                0,
+                                                              ),
+                                                          bottomRight:
+                                                              Radius.circular(
+                                                                0,
+                                                              ),
+                                                        ),
+                                                    child: Image.memory(
+                                                      info.thumb!,
+                                                      width: 56,
+                                                      height: 56,
+                                                      fit: BoxFit.cover,
+                                                    ),
+                                                  )
+                                                else
+                                                  Container(
+                                                    width: 56,
+                                                    height: 56,
+                                                    decoration: const BoxDecoration(
+                                                      color: Color(0xFFE0E0E0),
+                                                      borderRadius:
+                                                          BorderRadius.only(
+                                                            topLeft:
+                                                                Radius.circular(
+                                                                  16,
+                                                                ),
+                                                            bottomLeft:
+                                                                Radius.circular(
+                                                                  16,
+                                                                ),
+                                                            topRight:
+                                                                Radius.circular(
+                                                                  0,
+                                                                ),
+                                                            bottomRight:
+                                                                Radius.circular(
+                                                                  0,
+                                                                ),
+                                                          ),
+                                                    ),
+                                                    child: const Icon(
+                                                      Icons.photo,
+                                                      size: 28,
+                                                      color: Colors.grey,
+                                                    ),
+                                                  ),
+                                                const SizedBox(width: 16),
+                                                Expanded(
+                                                  child: Padding(
+                                                    padding:
+                                                        const EdgeInsets.symmetric(
+                                                          vertical: 8,
+                                                        ),
+                                                    child: Text(
+                                                      info.name,
+                                                      style: const TextStyle(
+                                                        fontSize: 16,
+                                                        fontWeight:
+                                                            FontWeight.w500,
+                                                      ),
+                                                      overflow:
+                                                          TextOverflow.ellipsis,
+                                                    ),
                                                   ),
                                                 ),
-                                                const SizedBox(width: 4),
-                                                const Icon(
-                                                  Icons.photo_library_outlined,
-                                                  size: 18,
+                                                const SizedBox(width: 12),
+                                                Row(
+                                                  mainAxisSize:
+                                                      MainAxisSize.min,
+                                                  children: [
+                                                    Text(
+                                                      '${info.count}',
+                                                      style: const TextStyle(
+                                                        fontSize: 14,
+                                                      ),
+                                                    ),
+                                                    const SizedBox(width: 4),
+                                                    const Icon(
+                                                      Icons
+                                                          .photo_library_outlined,
+                                                      size: 18,
+                                                    ),
+                                                  ],
                                                 ),
+                                                const SizedBox(width: 12),
                                               ],
                                             ),
-                                            const SizedBox(width: 12),
-                                          ],
+                                          ),
                                         ),
                                       ),
                                     ),
-                                  ),
+                                    const SizedBox(width: 24),
+                                  ],
                                 );
                               },
                             );
                           },
                         ),
                       ),
+                      const SizedBox(height: 16),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          Expanded(
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 24,
+                              ),
+                              child: Material(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.surfaceVariant.withOpacity(0.8),
+                                borderRadius: BorderRadius.circular(16),
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(16),
+                                  onTap: () {
+                                    /* TODO: Add album */
+                                  },
+                                  child: SizedBox(
+                                    height: 48,
+                                    child: Center(
+                                      child: Row(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: const [
+                                          Icon(Icons.add, size: 22),
+                                          SizedBox(width: 8),
+                                          Text(
+                                            'Add',
+                                            style: TextStyle(
+                                              fontSize: 16,
+                                              fontWeight: FontWeight.w500,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 24,
+                              ),
+                              child: Material(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.surfaceVariant.withOpacity(0.8),
+                                borderRadius: BorderRadius.circular(16),
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(16),
+                                  onTap: () => Navigator.of(context).pop(),
+                                  child: SizedBox(
+                                    height: 48,
+                                    child: Center(
+                                      child: Text(
+                                        'Close',
+                                        style: TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w500,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 28),
                     ],
                   ),
                 ),

--- a/lib/services/photo_action_service.dart
+++ b/lib/services/photo_action_service.dart
@@ -83,4 +83,15 @@ class PhotoActionService {
       return [];
     }
   }
+
+  static Future<bool> createAlbum(String albumName) async {
+    try {
+      final result = await _albumsChannel.invokeMethod('createAlbum', {
+        'album': albumName,
+      });
+      return result == true;
+    } catch (_) {
+      return false;
+    }
+  }
 }

--- a/lib/services/photo_action_service.dart
+++ b/lib/services/photo_action_service.dart
@@ -4,7 +4,10 @@ import 'package:flutter/services.dart';
 import 'package:photo_manager/photo_manager.dart';
 
 class PhotoActionService {
-  static const MethodChannel _channel = MethodChannel('picsor.favorite');
+  static const MethodChannel _favoriteChannel = MethodChannel(
+    'picsor.favorite',
+  );
+  static const MethodChannel _albumsChannel = MethodChannel('picsor.albums');
 
   /// Checks the system-level favorite status for the given photo id.
   static Future<bool> isSystemFavorite(String id) async {
@@ -15,7 +18,7 @@ class PhotoActionService {
       }
       // Use only the localIdentifier part for native call
       final systemId = id.split('/').first;
-      final result = await _channel.invokeMethod('isFavorite', {
+      final result = await _favoriteChannel.invokeMethod('isFavorite', {
         'id': systemId,
       });
       return result == true;
@@ -30,7 +33,7 @@ class PhotoActionService {
     try {
       final asset = photo.asset;
       final newValue = !asset.isFavorite;
-      final result = await _channel.invokeMethod('setFavorite', {
+      final result = await _favoriteChannel.invokeMethod('setFavorite', {
         'id': photo.id,
         'favorite': newValue,
       });
@@ -57,8 +60,27 @@ class PhotoActionService {
     }
   }
 
-  static Future<void> addToAlbum(PhotoModel photo) async {
-    // Placeholder for future album logic
-    // Implement using photo_manager album APIs
+  static Future<bool> addToAlbum(PhotoModel photo, String albumName) async {
+    try {
+      final result = await _albumsChannel.invokeMethod('addToAlbum', {
+        'id': photo.id,
+        'album': albumName,
+      });
+      return result == true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static Future<List<String>> getAlbums() async {
+    try {
+      final result = await _albumsChannel.invokeMethod('getAlbums');
+      if (result is List) {
+        return result.map((e) => e.toString()).toList();
+      }
+      return [];
+    } catch (_) {
+      return [];
+    }
   }
 }


### PR DESCRIPTION
What’s Included

- Album picker popup: Modern, blurry background, responsive design.  
- Show all local albums:  
  - iOS: native system albums  
  - Android: folders under DCIM/PicSor  
- Add photo to existing album with one tap.  
- Create new album directly from the popup (works on both iOS and Android).  
- Add photo to new album immediately after creation.  
- Robust error handling: Only shows error if something fails.  
- No cloud/Google Photos integration: Everything is local/offline for privacy and speed.  
- UI/UX polish: Spacing, padding, modern buttons, and smooth feedback.

Technical Details

- Platform channel for albums: `picsor.albums`  
  - iOS: Uses PHAssetCollection  
  - Android: Folder under DCIM/PicSor  
- Album creation and add-to-album logic implemented natively and called from Dart.  
- Album list shows thumbnail, album name, and photo count.  
- All album actions are offline and local-only.

Known Limitations

- Android:  
  - Only local albums (folders) are supported.  
  - Google Photos (cloud albums) are not supported or visible.  
- iOS: Works with all albums in the Photos app.  
- No batch add (only one photo at a time).

How to Test

1. Open album picker from a photo.  
2. Try adding the photo to an existing album.  
3. Try creating a new album and adding the photo.  
4. Test on both iOS and Android (ensure there are local photos on the device).
